### PR TITLE
静态常量折叠pass

### DIFF
--- a/framework/include/nndeploy/net/optimizer.h
+++ b/framework/include/nndeploy/net/optimizer.h
@@ -17,7 +17,10 @@ enum OptPassType : int {
 
   // Eliminate useless op
   kOptPassTypeEliminateCommonSubexpression,
-  kOptPassTypeEliminateDeadOp
+  kOptPassTypeEliminateDeadOp,
+
+  // Constant Folding
+  kOptPassTypeFoldConstant,
 };
 
 class OptPass {
@@ -65,6 +68,30 @@ class OptPass {
       std::vector<TensorWrapper*>& tensor_repository,
       std::vector<OpWrapper*>& op_repository,
       const std::vector<ir::OpType>& types, int begin_op_index);
+
+  /**
+   * @brief 将一个Op从它前驱的后继中删除
+   */
+  virtual base::Status rmOpFromPredecessor(OpWrapper* op_wrapper);
+
+  /**
+   * @brief 将一个Op从它后继的前驱中删除
+   */
+  virtual base::Status rmOpFromSuccessors(OpWrapper* op_wrapper);
+
+  /**
+   * @brief 处理一个Op的输入Tensor
+   *  将该Op从Tensor的消费者中删除，如果该Tensor的消费者仅有这一个Op作为消费者，则释放该Tensor
+   */
+  virtual base::Status rmInputTensorAndMaybeDelete(
+      OpWrapper* op_wrapper, std::vector<TensorWrapper*>& tensor_repository);
+
+  /**
+   * @brief 处理一个Op的输出Tensor
+   *  将该Op从Tensor的生产者中删除，如果该Tensor的生产者仅有这一个Op作为生产者，则释放该Tensor
+   */
+  virtual base::Status rmOutputTensorAndMaybeDelete(
+      OpWrapper* op_wrapper, std::vector<TensorWrapper*>& tensor_repository);
 
   virtual base::Status optimize(std::vector<TensorWrapper*>& tensor_repository,
                                 std::vector<OpWrapper*>& op_repository,

--- a/framework/include/nndeploy/net/optimizer/fold_constant.h
+++ b/framework/include/nndeploy/net/optimizer/fold_constant.h
@@ -1,0 +1,26 @@
+#ifndef _NNDEPLOY_NET_OPTIMIZER_FOLD_CONSTANT_H_
+#define _NNDEPLOY_NET_OPTIMIZER_FOLD_CONSTANT_H_
+
+#include "nndeploy/net/optimizer.h"
+
+namespace nndeploy {
+
+namespace net {
+
+/**
+ * 静态常量折叠
+ * 检测编译器可以运行的Op，即所有输入都是常量
+ */
+class FoldConstant : public OptPass {
+ public:
+  FoldConstant();
+  virtual ~FoldConstant();
+
+  virtual base::Status optimize(std::vector<TensorWrapper*>& tensor_repository,
+                                std::vector<OpWrapper*>& op_repository,
+                                int begin_op_index);
+};
+}  // namespace net
+}  // namespace nndeploy
+
+#endif

--- a/framework/source/nndeploy/net/optimizer/eliminate_common_subexpression.cc
+++ b/framework/source/nndeploy/net/optimizer/eliminate_common_subexpression.cc
@@ -144,19 +144,8 @@ base::Status EliminateCommonSubexpression::optimize(
       op_wrapper_map[op_wrapper] = op_wrapper;
       op_wrapper_it++;
     } else {
-      std::set<TensorWrapper*> to_delete_tensors;
-
       // 要保留的公共Op
       auto reserved_op_wrapper = op_wrapper_map[op_wrapper];
-
-      // 如果某个Tensor的消费者包含当前待删除的Op，则删去
-      for (auto tensor_wrapper : tensor_repository) {
-        auto it = std::find(tensor_wrapper->consumers_.begin(),
-                            tensor_wrapper->consumers_.end(), op_wrapper);
-        if (it != tensor_wrapper->consumers_.end()) {
-          tensor_wrapper->consumers_.erase(it);
-        }
-      }
 
       // 当前待删除的Op的输出Tensor,
       // 如果作为后继Op的输入Tensor，则需要将其替换为被保留的op的输出Tensor
@@ -179,43 +168,14 @@ base::Status EliminateCommonSubexpression::optimize(
         }
       }
 
-      for (auto tensor_wrapper : tensor_repository) {
-        auto prod_it = std::find(tensor_wrapper->producers_.begin(),
-                                 tensor_wrapper->producers_.end(), op_wrapper);
-        // 处理待删除op的输出Tensor
-        // 表明待删除的Op是当前TensorWrapper的生产者，则删去当前TensorWrapper
-        if (prod_it != tensor_wrapper->producers_.end()) {
-          // 该TensorWrapper的生产者只有一个，为被删除的op
-          // 删除该TensorWrapper
-          if (tensor_wrapper->producers_.size() == 1) {
-            to_delete_tensors.insert(tensor_wrapper);
+      // 处理待删除op的输出Tensor
+      rmOutputTensorAndMaybeDelete(op_wrapper, tensor_repository);
 
-          } else {
-            // 该TensorWrapper的生产者有多个
-            // 从生产者中删除 待删除的Opwrapper
-            tensor_wrapper->producers_.erase(prod_it);
-          }
-        }
-
-        // 处理待删除op的输入Tensor  同上
-        auto cons_it = std::find(tensor_wrapper->consumers_.begin(),
-                                 tensor_wrapper->consumers_.end(), op_wrapper);
-        if (cons_it != tensor_wrapper->consumers_.end()) {
-          if (tensor_wrapper->consumers_.size() == 1) {
-            to_delete_tensors.insert(tensor_wrapper);
-          } else {
-            tensor_wrapper->consumers_.erase(cons_it);
-          }
-        }
-      }
+      // 处理待删除op的输入Tensor
+      rmInputTensorAndMaybeDelete(op_wrapper, tensor_repository);
 
       // 从其前驱的后继中删除
-      for (auto predecessor : op_wrapper->predecessors_) {
-        predecessor->successors_.erase(
-            std::remove(predecessor->successors_.begin(),
-                        predecessor->successors_.end(), op_wrapper),
-            predecessor->successors_.end());
-      }
+      rmOpFromPredecessor(op_wrapper);
 
       // 将被删除的Op的后继的前驱改为被保留的Op
       for (auto successor : op_wrapper->successors_) {
@@ -227,24 +187,7 @@ base::Status EliminateCommonSubexpression::optimize(
         reserved_op_wrapper->successors_.emplace_back(successor);
       }
 
-      // 删除标记的TensorWrapper
-      for (auto tensor_wrapper : to_delete_tensors) {
-        if (tensor_wrapper->tensor_ != nullptr) {
-          delete tensor_wrapper->tensor_;
-          tensor_wrapper->tensor_ = nullptr;
-        }
-
-        NNDEPLOY_LOGE("delete tensor name: %s\n",
-                      tensor_wrapper->name_.c_str());
-        auto it = std::find(tensor_repository.begin(), tensor_repository.end(),
-                            tensor_wrapper);
-        if (it != tensor_repository.end()) {
-          tensor_repository.erase(it);
-        }
-
-        delete tensor_wrapper;
-      }
-
+      // 删除该Op
       auto it =
           std::find(op_repository.begin(), op_repository.end(), op_wrapper);
       if (it != op_repository.end()) {

--- a/framework/source/nndeploy/net/optimizer/eliminate_dead_op.cc
+++ b/framework/source/nndeploy/net/optimizer/eliminate_dead_op.cc
@@ -41,61 +41,19 @@ base::Status EliminateDeadOp::optimize(
 
   // 消除这个无用节点
   if (!use_flag) {
-    std::set<TensorWrapper*> to_delete_tensors;
-
     // 将其从前驱节点的后继节点中删除
-    for (auto predecessor : op_wrapper->predecessors_) {
-      auto it = std::find(predecessor->successors_.begin(),
-                          predecessor->successors_.end(), op_wrapper);
-      if (it != predecessor->successors_.end()) {
-        predecessor->successors_.erase(it);
-      }
-    }
+    rmOpFromPredecessor(op_wrapper);
 
     // 处理被删除节点的输出Tensor
     // 若该Tensor仅有这一个生产者Op，则删除该Tensor
     // 若该Tensor其中一个生产者Op是该Op，则从其生产者Op中删除该Op
-    for (auto tensor_wrapper : tensor_repository) {
-      auto prod_it = std::find(tensor_wrapper->producers_.begin(),
-                               tensor_wrapper->producers_.end(), op_wrapper);
-      if (prod_it != tensor_wrapper->producers_.end()) {
-        if (tensor_wrapper->producers_.size() == 1) {
-          to_delete_tensors.insert(tensor_wrapper);
-        } else {
-          tensor_wrapper->producers_.erase(prod_it);
-        }
-      }
-    }
+
+    rmOutputTensorAndMaybeDelete(op_wrapper, tensor_repository);
 
     // 处理被删除节点的输入Tensor
     // 若该Tensor仅有这一个消费者Op，则删除该Tensor
     // 若该Tensor其中一个消费者Op是该Op，则从其消费者Op中删除该Op
-    for (auto tensor_wrapper : tensor_repository) {
-      auto cons_it = std::find(tensor_wrapper->consumers_.begin(),
-                               tensor_wrapper->consumers_.end(), op_wrapper);
-      if (cons_it != tensor_wrapper->consumers_.end()) {
-        if (tensor_wrapper->consumers_.size() == 1) {
-          to_delete_tensors.insert(tensor_wrapper);
-        } else {
-          tensor_wrapper->consumers_.erase(cons_it);
-        }
-      }
-    }
-
-    // 删除标记的TensorWrapper
-    for (auto tensor_wrapper : to_delete_tensors) {
-      if (tensor_wrapper->tensor_ != nullptr) {
-        delete tensor_wrapper->tensor_;
-        tensor_wrapper->tensor_ = nullptr;
-      }
-      NNDEPLOY_LOGE("delete tensor name: %s\n", tensor_wrapper->name_.c_str());
-      auto it = std::find(tensor_repository.begin(), tensor_repository.end(),
-                          tensor_wrapper);
-      if (it != tensor_repository.end()) {
-        tensor_repository.erase(it);
-      }
-      delete tensor_wrapper;
-    }
+    rmInputTensorAndMaybeDelete(op_wrapper, tensor_repository);
 
     //将待删除Op从Op仓库删除
     auto it = std::find(op_repository.begin(), op_repository.end(), op_wrapper);

--- a/framework/source/nndeploy/net/optimizer/fold_constant.cc
+++ b/framework/source/nndeploy/net/optimizer/fold_constant.cc
@@ -1,0 +1,168 @@
+#include "nndeploy/net/optimizer/fold_constant.h"
+
+#include "nndeploy/ir/op_param.h"
+
+namespace nndeploy {
+
+namespace net {
+
+/**
+ * 是否是确定性算子
+ * 无论执行多少次，节点都会产生相同的输出。如果节点涉及任何非确定性操作（例如随机数生成），则不能进行常量折叠。
+ */
+bool isDeterministic(const OpWrapper* op_wrapper) {
+  std::set<ir::OpType> non_deterministic_ops{
+      ir::kOpTypeRandomNormal,
+      ir::kOpTypeRandomNormalLike,
+      ir::kOpTypeRandomUniform,
+      ir::kOpTypeRandomUniformLike,
+  };
+
+  auto it =
+      std::find(non_deterministic_ops.begin(), non_deterministic_ops.end(),
+                op_wrapper->op_->getOpType());
+  return it == non_deterministic_ops.end();
+}
+
+/**
+ * 是否是量化相关算子
+ */
+bool isQDQ(const OpWrapper* op_wrapper) {
+  std::set<ir::OpType> quant_ops{ir::kOpTypeQuantizeLinear,
+                                 ir::kOpTypeDequantizeLinear};
+  auto it = std::find(quant_ops.begin(), quant_ops.end(),
+                      op_wrapper->op_->getOpType());
+  return it == quant_ops.end();
+}
+
+/**
+ * 输入是否都是常量
+ */
+bool isAllInputConstant(const OpWrapper* op_wrapper,
+                        const std::vector<TensorWrapper*>& tensor_repository) {
+  for (auto tensor_wrapper : tensor_repository) {
+    auto it = std::find(tensor_wrapper->consumers_.begin(),
+                        tensor_wrapper->consumers_.end(), op_wrapper);
+    if (it != tensor_wrapper->consumers_.end()) {
+      // tensor是Op的输入，且不是常量，则返回false
+      if (!tensor_wrapper->is_weight_) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * TODO:参考OnnxSim
+ * 输出张量大小不超过特定阈值：如果节点的输出张量过大，可能会超出内存限制或导致性能问题，因此可能需要避免常量折叠。
+ * 当前暂时全部返回false
+ */
+bool produceLargeTensor(const OpWrapper* op_wrapper,
+                        const std::vector<TensorWrapper*>& tensor_repository) {
+  return false;
+}
+
+/**
+ * 该算子是否支持常量折叠
+ * 有一些需要获取运行时信息的算子不支持折叠
+ */
+bool isSupportFold(const OpWrapper* op_wrapper) { return true; }
+/**
+ * 运行这个可折叠的Op
+ * 在Net构建时该op的input、output都已set，但是output没有分配内存
+ */
+base::Status runOp(const OpWrapper* op_wrapper) {
+  base::Status status = base::kStatusCodeOk;
+  op::Op* op = op_wrapper->op_;
+
+  status = op->init();
+  NNDEPLOY_RETURN_ON_NEQ(status, base::kStatusCodeOk, "init failed");
+  status = op->preRun();
+  NNDEPLOY_RETURN_ON_NEQ(status, base::kStatusCodeOk, "preRun failed");
+  status = op->checkOrAllocOutput();
+  NNDEPLOY_RETURN_ON_NEQ(status, base::kStatusCodeOk,
+                         "checkOrAllocOutput failed");
+  status = op->run();
+  NNDEPLOY_RETURN_ON_NEQ(status, base::kStatusCodeOk, "run failed");
+  status = op->postRun();
+  NNDEPLOY_RETURN_ON_NEQ(status, base::kStatusCodeOk, "postRun failed");
+  status = op->deinit();
+  NNDEPLOY_RETURN_ON_NEQ(status, base::kStatusCodeOk, "deinit failed");
+
+  return status;
+}
+
+FoldConstant::FoldConstant(){};
+FoldConstant::~FoldConstant(){};
+
+base::Status FoldConstant::optimize(
+    std::vector<TensorWrapper*>& tensor_repository,
+    std::vector<OpWrapper*>& op_repository, int begin_op_index) {
+  if (begin_op_index < 0 || begin_op_index >= op_repository.size()) {
+    return base::kStatusCodeOk;
+  }
+
+  OpWrapper* op_wrapper = op_repository[begin_op_index];
+  bool fold_flag = false;
+
+  if (isDeterministic(op_wrapper) && !isQDQ(op_wrapper) &&
+      !produceLargeTensor(op_wrapper, tensor_repository) &&
+      isAllInputConstant(op_wrapper, tensor_repository) &&
+      isSupportFold(op_wrapper)) {
+    base::Status status = runOp(op_wrapper);
+    if (status == base::kStatusCodeOk) {
+      fold_flag = true;
+
+      // 这个算子已经提前计算 ，将其删除， 思路与删除死节点类似
+
+      // 将已经计算好的输出Tensor，标记为常量
+      for (auto tensor_wrapper : tensor_repository) {
+        auto it = std::find(tensor_wrapper->producers_.begin(),
+                            tensor_wrapper->producers_.end(), op_wrapper);
+        if (it != tensor_wrapper->producers_.end()) {
+          tensor_wrapper->is_weight_ = true;
+        }
+      }
+
+      //处理这个Op的输入Tensor
+      rmInputTensorAndMaybeDelete(op_wrapper, tensor_repository);
+
+      //处理这个Op的输出Tensor
+      rmOutputTensorAndMaybeDelete(op_wrapper, tensor_repository);
+
+      // 将其从前驱节点的后继节点中删除
+      rmOpFromPredecessor(op_wrapper);
+
+      // 将其从后继节点的前驱节点中删除
+      rmOpFromSuccessors(op_wrapper);
+
+      // 将待删除Op从Op仓库删除
+      auto it =
+          std::find(op_repository.begin(), op_repository.end(), op_wrapper);
+      if (it != op_repository.end()) {
+        if (op_wrapper->op_ != nullptr) {
+          delete op_wrapper->op_;
+          op_wrapper->op_ = nullptr;
+        }
+        op_repository.erase(it);
+        NNDEPLOY_LOGE("delete op name: %s\n", op_wrapper->name_.c_str());
+        delete op_wrapper;
+      }
+    }
+  }
+
+  if (fold_flag) {
+    // 由于消除了一个Op，所以下次索引不加1
+    return optimize(tensor_repository, op_repository, begin_op_index);
+  } else {
+    return optimize(tensor_repository, op_repository, begin_op_index + 1);
+  }
+}
+
+TypeOptPassRegister<TypeOptPassCreator<FoldConstant>> g_fold_constant_register(
+    base::kDeviceTypeCodeCpu, kOptPassTypeFoldConstant);
+
+}  // namespace net
+
+}  // namespace nndeploy

--- a/framework/source/nndeploy/net/optimizer/fuse_conv_batchnorm.cc
+++ b/framework/source/nndeploy/net/optimizer/fuse_conv_batchnorm.cc
@@ -90,32 +90,7 @@ base::Status FuseConvBatchNorm::optimize(
   }
 
   // 删除原batchnorm的权重
-  std::set<TensorWrapper*> to_delete_tensors;
-  for (auto tensor_wrapper : tensor_repository) {
-    auto cons_it = std::find(tensor_wrapper->consumers_.begin(),
-                             tensor_wrapper->consumers_.end(), last_op);
-    if (cons_it != tensor_wrapper->consumers_.end()) {
-      if (tensor_wrapper->consumers_.size() == 1) {
-        to_delete_tensors.insert(tensor_wrapper);
-      } else {
-        tensor_wrapper->consumers_.erase(cons_it);
-      }
-    }
-  }
-  // 删除标记的TensorWrapper
-  for (auto tensor_wrapper : to_delete_tensors) {
-    if (tensor_wrapper->tensor_ != nullptr) {
-      delete tensor_wrapper->tensor_;
-      tensor_wrapper->tensor_ = nullptr;
-    }
-    NNDEPLOY_LOGE("delete tensor name: %s\n", tensor_wrapper->name_.c_str());
-    auto it = std::find(tensor_repository.begin(), tensor_repository.end(),
-                        tensor_wrapper);
-    if (it != tensor_repository.end()) {
-      tensor_repository.erase(it);
-    }
-    delete tensor_wrapper;
-  }
+  rmInputTensorAndMaybeDelete(last_op, tensor_repository);
 
   // 更新op_repository
   status = seqPatternMatchUpateOpRepository(tensor_repository, op_repository,


### PR DESCRIPTION
1. 静态常量折叠pass

2. 优化了pass的常用工具函数，大部分pass都是在做如下操作，封装一下

``` cpp

  /**
   * @brief 将一个Op从它前驱的后继中删除
   */
  virtual base::Status rmOpFromPredecessor(OpWrapper* op_wrapper);

  /**
   * @brief 将一个Op从它后继的前驱中删除
   */
  virtual base::Status rmOpFromSuccessors(OpWrapper* op_wrapper);

  /**
   * @brief 处理一个Op的输入Tensor
   *  将该Op从Tensor的消费者中删除，如果该Tensor的消费者仅有这一个Op作为消费者，则释放该Tensor
   */
  virtual base::Status rmInputTensorAndMaybeDelete(
      OpWrapper* op_wrapper, std::vector<TensorWrapper*>& tensor_repository);

  /**
   * @brief 处理一个Op的输出Tensor
   *  将该Op从Tensor的生产者中删除，如果该Tensor的生产者仅有这一个Op作为生产者，则释放该Tensor
   */
  virtual base::Status rmOutputTensorAndMaybeDelete(
      OpWrapper* op_wrapper, std::vector<TensorWrapper*>& tensor_repository);
```