### PR TITLE
图优化pass 优先级

### DIFF
--- a/framework/include/nndeploy/net/optimizer.h
+++ b/framework/include/nndeploy/net/optimizer.h
@@ -25,7 +25,7 @@ enum OptPassType : int {
 
 class OptPass {
  public:
-  OptPass();
+  OptPass(std::string name);
   virtual ~OptPass();
 
   /**
@@ -93,9 +93,14 @@ class OptPass {
   virtual base::Status rmOutputTensorAndMaybeDelete(
       OpWrapper* op_wrapper, std::vector<TensorWrapper*>& tensor_repository);
 
+  std::string getName();
+
   virtual base::Status optimize(std::vector<TensorWrapper*>& tensor_repository,
                                 std::vector<OpWrapper*>& op_repository,
                                 int begin_op_index) = 0;
+
+ private:
+  std::string name_;  // pass名称
 };
 
 /**
@@ -124,11 +129,10 @@ class TypeOptPassCreator : public OptPassCreator {
 /**
  * @brief Get the Global OptPass Creator Map object
  *
- * @return std::map<ExecutorType, std::map<const std::string &,
- * std::shared_ptr<OptPassCreator>>>&
+ *  设备类型  ->  优化等级  -> Pass类型
  */
 std::map<base::DeviceTypeCode,
-         std::map<OptPassType, std::shared_ptr<OptPassCreator>>>&
+         std::map<int, std::map<OptPassType, std::shared_ptr<OptPassCreator>>>>&
 getGlobalOptPassCreatorMap();
 
 /**
@@ -139,22 +143,33 @@ getGlobalOptPassCreatorMap();
 template <typename T>
 class TypeOptPassRegister {
  public:
+  /**
+   * level表示优先级，数字越小，优先级越高，在图优化时先执行，最高优先级
+   * level=1； 例如FuseConvBatchNorm在FuseConvRelu之前运行
+   */
   explicit TypeOptPassRegister(base::DeviceTypeCode device_type_code,
-                               OptPassType type) {
+                               OptPassType type, int level) {
     auto& creator_map = getGlobalOptPassCreatorMap();
     auto device_map = creator_map.find(device_type_code);
     if (device_map == creator_map.end()) {
       creator_map[device_type_code] =
+          std::map<int,
+                   std::map<OptPassType, std::shared_ptr<OptPassCreator>>>();
+    }
+    auto level_map = creator_map[device_type_code].find(level);
+    if (level_map == creator_map[device_type_code].end()) {
+      creator_map[device_type_code][level] =
           std::map<OptPassType, std::shared_ptr<OptPassCreator>>();
     }
-    auto creator = creator_map[device_type_code].find(type);
-    if (creator == creator_map[device_type_code].end()) {
-      creator_map[device_type_code][type] = std::shared_ptr<T>(new T());
+
+    auto creator = creator_map[device_type_code][level].find(type);
+    if (creator == creator_map[device_type_code][level].end()) {
+      creator_map[device_type_code][level][type] = std::shared_ptr<T>(new T());
     }
   }
 };
 
-std::shared_ptr<OptPass> createOptPass(base::DeviceType device_type,
+std::shared_ptr<OptPass> createOptPass(base::DeviceType device_type, int level,
                                        OptPassType type);
 
 class NNDEPLOY_CC_API Optimizer {
@@ -167,7 +182,7 @@ class NNDEPLOY_CC_API Optimizer {
                     std::set<OptPassType> disable_pass);
   base::Status deinit();
 
-  base::Status addPass(OptPassType type);
+  base::Status addPass(OptPassType type, int level);
   base::Status removePass(OptPassType type);
 
   base::Status optimize(std::vector<TensorWrapper*>& tensor_repository,
@@ -175,7 +190,9 @@ class NNDEPLOY_CC_API Optimizer {
 
  protected:
   base::DeviceType device_type_;
-  std::map<OptPassType, std::shared_ptr<OptPass>> opt_passes_;
+  std::map<int, std::map<OptPassType, std::shared_ptr<OptPass>>>
+      opt_passes_;  // 第一个key是优先级，数字越小， 优先级越高，
+                    // 在图优化时首先执行这个pass
 };
 
 }  // namespace net

--- a/framework/include/nndeploy/net/optimizer.h
+++ b/framework/include/nndeploy/net/optimizer.h
@@ -23,6 +23,8 @@ enum OptPassType : int {
   kOptPassTypeFoldConstant,
 };
 
+class Net;
+
 class OptPass {
  public:
   OptPass(std::string name);
@@ -94,13 +96,17 @@ class OptPass {
       OpWrapper* op_wrapper, std::vector<TensorWrapper*>& tensor_repository);
 
   std::string getName();
+  base::Status setNet(Net* net);
 
   virtual base::Status optimize(std::vector<TensorWrapper*>& tensor_repository,
                                 std::vector<OpWrapper*>& op_repository,
                                 int begin_op_index) = 0;
 
- private:
+ protected:
   std::string name_;  // pass名称
+
+  Net* net_ =
+      nullptr;  //该pass所属的Net，可能要修改Net内部的数据，例如释放某些tensor
 };
 
 /**
@@ -186,7 +192,7 @@ class NNDEPLOY_CC_API Optimizer {
   base::Status removePass(OptPassType type);
 
   base::Status optimize(std::vector<TensorWrapper*>& tensor_repository,
-                        std::vector<OpWrapper*>& op_repository);
+                        std::vector<OpWrapper*>& op_repository, Net* net);
 
  protected:
   base::DeviceType device_type_;

--- a/framework/include/nndeploy/op/op.h
+++ b/framework/include/nndeploy/op/op.h
@@ -92,6 +92,8 @@ class NNDEPLOY_CC_API Op {
   std::vector<device::Tensor *> getAllInput();
   std::vector<device::Tensor *> getAllOutput();
 
+  base::Status rmInput(device::Tensor *tensor);
+
   base::Status setAllInput(std::vector<device::Tensor *> inputs);
   base::Status setAllOutput(std::vector<device::Tensor *> outputs);
 

--- a/framework/source/nndeploy/net/net.cc
+++ b/framework/source/nndeploy/net/net.cc
@@ -729,7 +729,7 @@ base::Status Net::optimizer() {
       std::make_unique<net::Optimizer>();
   status = optimizer->init(device_type_, enable_pass_, disable_pass_);
   NNDEPLOY_RETURN_ON_NEQ(status, base::kStatusCodeOk, "optimizer init failed!");
-  status = optimizer->optimize(tensor_repository_, op_repository_);
+  status = optimizer->optimize(tensor_repository_, op_repository_, this);
   NNDEPLOY_RETURN_ON_NEQ(status, base::kStatusCodeOk,
                          "optimizer optimize failed!");
   return status;

--- a/framework/source/nndeploy/net/optimizer.cc
+++ b/framework/source/nndeploy/net/optimizer.cc
@@ -108,28 +108,7 @@ base::Status OptPass::seqPatternMatchUpateTensorRepository(
   // 删除除最后一个op以外所有的输出
   OpWrapper* current_op = first_op;
   while (current_op != last_op) {
-    for (TensorWrapper* tensor : tensor_repository) {
-      if (tensor->producers_.size() != 1) {
-        continue;
-      }
-      if (tensor->producers_[0] == current_op) {
-        // 手动删除成员变量tensor_
-        if (tensor->tensor_ != nullptr) {
-          delete tensor->tensor_;
-          tensor->tensor_ = nullptr;
-        }
-        // 从vector移除该tensor
-        auto it = std::find(tensor_repository.begin(), tensor_repository.end(),
-                            tensor);
-        if (it != tensor_repository.end()) {
-          NNDEPLOY_LOGE("delete tensor name: %s\n", tensor->name_.c_str());
-          tensor_repository.erase(it);
-        }
-        // tensor_repository.erase(tensor);
-        // 删除TensorWrapper对象
-        delete tensor;
-      }
-    }
+    rmOutputTensorAndMaybeDelete(current_op, tensor_repository);
     current_op = current_op->successors_[0];
   }
 

--- a/framework/source/nndeploy/net/optimizer.cc
+++ b/framework/source/nndeploy/net/optimizer.cc
@@ -4,9 +4,11 @@ namespace nndeploy {
 namespace net {
 
 // OptPass
-OptPass::OptPass() {}
+OptPass::OptPass(std::string name) { name_ = name; }
 
 OptPass::~OptPass() {}
+
+std::string OptPass::getName() { return name_; }
 
 /**
  * @brief 模式匹配
@@ -293,30 +295,35 @@ base::Status OptPass::rmInputTensorAndMaybeDelete(
 }
 
 // 工厂模式
+// 设备类型  ->  优化等级  -> Pass类型
 std::map<base::DeviceTypeCode,
-         std::map<OptPassType, std::shared_ptr<OptPassCreator>>>&
+         std::map<int, std::map<OptPassType, std::shared_ptr<OptPassCreator>>>>&
 getGlobalOptPassCreatorMap() {
   static std::once_flag once;
-  static std::shared_ptr<
-      std::map<base::DeviceTypeCode,
-               std::map<OptPassType, std::shared_ptr<OptPassCreator>>>>
+  static std::shared_ptr<std::map<
+      base::DeviceTypeCode,
+      std::map<int, std::map<OptPassType, std::shared_ptr<OptPassCreator>>>>>
       creators;
   std::call_once(once, []() {
     creators.reset(
         new std::map<base::DeviceTypeCode,
-                     std::map<OptPassType, std::shared_ptr<OptPassCreator>>>);
+                     std::map<int, std::map<OptPassType,
+                                            std::shared_ptr<OptPassCreator>>>>);
   });
   return *creators;
 }
 
-std::shared_ptr<OptPass> createOptPass(base::DeviceType device_type,
+std::shared_ptr<OptPass> createOptPass(base::DeviceType device_type, int level,
                                        OptPassType type) {
   auto& creator_map = getGlobalOptPassCreatorMap();
   auto device_map = creator_map.find(device_type.code_);
   if (device_map != creator_map.end()) {
-    auto pass_creator = device_map->second.find(type);
-    if (pass_creator != device_map->second.end()) {
-      return pass_creator->second->createOptPass();
+    auto level_map = device_map->second.find(level);
+    if (level_map != device_map->second.end()) {
+      auto pass_creator = level_map->second.find(type);
+      if (pass_creator != level_map->second.end()) {
+        return pass_creator->second->createOptPass();
+      }
     }
   }
   return nullptr;
@@ -334,20 +341,27 @@ base::Status Optimizer::init(base::DeviceType device_type,
   auto& creator_map = getGlobalOptPassCreatorMap();
   auto device_map = creator_map.find(device_type.code_);
   if (device_map != creator_map.end()) {
-    for (auto& pass_creator : device_map->second) {
-      // 设置了仅启用某些pass，当前pass不在的话则跳过
-      if (!enable_pass.empty() &&
-          enable_pass.find(pass_creator.first) == enable_pass.end()) {
-        continue;
-      }
+    //根据Pass优先级进行图优化
+    for (auto level_map : device_map->second) {
+      for (auto& pass_creator : level_map.second) {
+        // 设置了仅启用某些pass，当前pass不在的话则跳过
+        if (!enable_pass.empty() &&
+            enable_pass.find(pass_creator.first) == enable_pass.end()) {
+          continue;
+        }
 
-      // 设置了禁用某些pass，当前pass在的话则跳过
-      if (enable_pass.empty() && !disable_pass.empty() &&
-          disable_pass.find(pass_creator.first) != disable_pass.end()) {
-        continue;
+        // 设置了禁用某些pass，当前pass在的话则跳过
+        if (enable_pass.empty() && !disable_pass.empty() &&
+            disable_pass.find(pass_creator.first) != disable_pass.end()) {
+          continue;
+        }
+        if (opt_passes_.find(level_map.first) == opt_passes_.end()) {
+          opt_passes_[level_map.first] =
+              std::map<OptPassType, std::shared_ptr<OptPass>>();
+        }
+        opt_passes_[level_map.first][pass_creator.first] =
+            pass_creator.second->createOptPass();
       }
-
-      opt_passes_[pass_creator.first] = pass_creator.second->createOptPass();
     }
   }
   return base::kStatusCodeOk;
@@ -356,26 +370,43 @@ base::Status Optimizer::deinit() {
   opt_passes_.clear();
   return base::kStatusCodeOk;
 }
-base::Status Optimizer::addPass(OptPassType type) {
+base::Status Optimizer::addPass(OptPassType type, int level) {
   if (opt_passes_.find(type) == opt_passes_.end()) {
-    opt_passes_[type] = createOptPass(device_type_, type);
+    if (opt_passes_.find(level) == opt_passes_.end()) {
+      opt_passes_[level] = std::map<OptPassType, std::shared_ptr<OptPass>>();
+    }
+    opt_passes_[level][type] = createOptPass(device_type_, level, type);
   }
   return base::kStatusCodeOk;
 }
 base::Status Optimizer::removePass(OptPassType type) {
-  if (opt_passes_.find(type) != opt_passes_.end()) {
-    opt_passes_.erase(type);
+  // 遍历外层 map
+  for (auto& outer_pair : opt_passes_) {
+    // 在内层 map 中找到对应的 OptPassType
+    auto& inner_map = outer_pair.second;
+    auto it = inner_map.find(type);
+    if (it != inner_map.end()) {
+      // 找到了，从内层 map 中删除
+      inner_map.erase(it);
+      // 如果内层 map 为空，从外层 map 删除这个元素
+      if (inner_map.empty()) {
+        opt_passes_.erase(outer_pair.first);
+      }
+    }
   }
   return base::kStatusCodeOk;
 }
 base::Status Optimizer::optimize(std::vector<TensorWrapper*>& tensor_repository,
                                  std::vector<OpWrapper*>& op_repository) {
   base::Status status = base::kStatusCodeOk;
-  for (auto& pass : opt_passes_) {
-    status = pass.second->optimize(tensor_repository, op_repository, 0);
-    if (status != base::kStatusCodeOk) {
-      NNDEPLOY_LOGE("optimize failed!\n");
-      return status;
+  for (auto& level_map : opt_passes_) {
+    for (auto& pass : level_map.second) {
+      NNDEPLOY_LOGE("Execute pass: %s\n", pass.second->getName().c_str());
+      status = pass.second->optimize(tensor_repository, op_repository, 0);
+      if (status != base::kStatusCodeOk) {
+        NNDEPLOY_LOGE("optimize failed!\n");
+        return status;
+      }
     }
   }
   return base::kStatusCodeOk;

--- a/framework/source/nndeploy/net/optimizer/eliminate_common_subexpression.cc
+++ b/framework/source/nndeploy/net/optimizer/eliminate_common_subexpression.cc
@@ -125,7 +125,8 @@ struct CSEOpEqual {
   }
 };
 
-EliminateCommonSubexpression::EliminateCommonSubexpression() {}
+EliminateCommonSubexpression::EliminateCommonSubexpression()
+    : OptPass("EliminateCommonSubexpression") {}
 
 EliminateCommonSubexpression::~EliminateCommonSubexpression() {}
 
@@ -208,7 +209,7 @@ base::Status EliminateCommonSubexpression::optimize(
 
 TypeOptPassRegister<TypeOptPassCreator<EliminateCommonSubexpression>>
     g_eliminate_common_subexpression_register(
-        base::kDeviceTypeCodeCpu, kOptPassTypeEliminateCommonSubexpression);
+        base::kDeviceTypeCodeCpu, kOptPassTypeEliminateCommonSubexpression, 3);
 
 }  // namespace net
 

--- a/framework/source/nndeploy/net/optimizer/eliminate_dead_op.cc
+++ b/framework/source/nndeploy/net/optimizer/eliminate_dead_op.cc
@@ -3,7 +3,7 @@
 namespace nndeploy {
 
 namespace net {
-EliminateDeadOp::EliminateDeadOp(){};
+EliminateDeadOp::EliminateDeadOp() : OptPass("EliminateDeadOp"){};
 EliminateDeadOp::~EliminateDeadOp(){};
 
 base::Status EliminateDeadOp::optimize(
@@ -78,7 +78,7 @@ base::Status EliminateDeadOp::optimize(
 
 TypeOptPassRegister<TypeOptPassCreator<EliminateDeadOp>>
     g_eliminate_dead_op_register(base::kDeviceTypeCodeCpu,
-                                 kOptPassTypeEliminateDeadOp);
+                                 kOptPassTypeEliminateDeadOp, 3);
 
 }  // namespace net
 

--- a/framework/source/nndeploy/net/optimizer/fold_constant.cc
+++ b/framework/source/nndeploy/net/optimizer/fold_constant.cc
@@ -93,7 +93,7 @@ base::Status runOp(const OpWrapper* op_wrapper) {
   return status;
 }
 
-FoldConstant::FoldConstant(){};
+FoldConstant::FoldConstant() : OptPass("FoldConstant"){};
 FoldConstant::~FoldConstant(){};
 
 base::Status FoldConstant::optimize(
@@ -161,7 +161,7 @@ base::Status FoldConstant::optimize(
 }
 
 TypeOptPassRegister<TypeOptPassCreator<FoldConstant>> g_fold_constant_register(
-    base::kDeviceTypeCodeCpu, kOptPassTypeFoldConstant);
+    base::kDeviceTypeCodeCpu, kOptPassTypeFoldConstant, 5);
 
 }  // namespace net
 

--- a/framework/source/nndeploy/net/optimizer/fuse_conv_batchnorm.cc
+++ b/framework/source/nndeploy/net/optimizer/fuse_conv_batchnorm.cc
@@ -3,7 +3,7 @@
 
 namespace nndeploy {
 namespace net {
-FuseConvBatchNorm::FuseConvBatchNorm(){};
+FuseConvBatchNorm::FuseConvBatchNorm() : OptPass("FuseConvBatchNorm"){};
 FuseConvBatchNorm::~FuseConvBatchNorm(){};
 
 base::Status FuseConvBatchNorm::optimize(
@@ -127,34 +127,14 @@ base::Status FuseConvBatchNorm::optimize(
     return status;
   }
 
-  // for (auto op_wrapper : op_repository) {
-  //   std::cout << op_wrapper->name_ << std::endl;
-  //   std::cout << "produce" << std::endl;
-  //   for (auto pre : op_wrapper->predecessors_) {
-  //     std::cout << pre->name_ << std::endl;
-  //   }
-  //   for (auto con : op_wrapper->successors_) {
-  //     std::cout << con->name_ << std::endl;
-  //   }
-  // }
-
-  // for (auto tensor_wrapper : tensor_repository) {
-  //   std::cout << tensor_wrapper->name_ << std::endl;
-  //   std::cout << "produce" << std::endl;
-  //   for (auto pre : tensor_wrapper->producers_) {
-  //     std::cout << pre->name_ << std::endl;
-  //   }
-  //   for (auto con : tensor_wrapper->consumers_) {
-  //     std::cout << con->name_ << std::endl;
-  //   }
-  // }
 
   return this->optimize(tensor_repository, op_repository, begin_op_index);
 }
 
 TypeOptPassRegister<TypeOptPassCreator<FuseConvBatchNorm>>
     g_fuse_conv_batchnorm_register(base::kDeviceTypeCodeCpu,
-                                   kOptPassTypeFuseConvBatchNorm);
+                                   kOptPassTypeFuseConvBatchNorm,
+                                   /*优化等级*/ 1);
 
 }  // namespace net
 }  // namespace nndeploy

--- a/framework/source/nndeploy/net/optimizer/fuse_conv_relu.cc
+++ b/framework/source/nndeploy/net/optimizer/fuse_conv_relu.cc
@@ -4,7 +4,7 @@
 namespace nndeploy {
 namespace net {
 
-FuseConvRelu::FuseConvRelu() {}
+FuseConvRelu::FuseConvRelu() : OptPass("FuseConvRelu") {}
 
 FuseConvRelu::~FuseConvRelu() {}
 
@@ -67,7 +67,7 @@ base::Status FuseConvRelu::optimize(
 }
 
 TypeOptPassRegister<TypeOptPassCreator<FuseConvRelu>> g_fuse_conv_relu_register(
-    base::kDeviceTypeCodeCpu, kOptPassTypeFuseConvRelu);
+    base::kDeviceTypeCodeCpu, kOptPassTypeFuseConvRelu, /*优化等级 */ 2);
 
 }  // namespace net
 }  // namespace nndeploy

--- a/framework/source/nndeploy/op/op.cc
+++ b/framework/source/nndeploy/op/op.cc
@@ -179,6 +179,14 @@ std::vector<std::string> Op::getAllOutputName() { return op_desc_.outputs_; }
 std::vector<device::Tensor *> Op::getAllInput() { return inputs_; }
 std::vector<device::Tensor *> Op::getAllOutput() { return outputs_; }
 
+base::Status Op::rmInput(device::Tensor *input) {
+  auto it = std::find(inputs_.begin(), inputs_.end(), input);
+  if (it != inputs_.end()) {
+    inputs_.erase(it);
+  }
+  return base::kStatusCodeOk;
+}
+
 base::Status Op::setAllInput(std::vector<device::Tensor *> inputs) {
   op_desc_.inputs_.clear();
   for (size_t i = 0; i < inputs.size(); ++i) {


### PR DESCRIPTION
1. 修复safetensors加载的weight无法被图优化修改的问题，使用copy on write，克隆并修改权重
2. 给图优化pass在注册时设定优先级，利用std::map的key的有序性，在图优化时可以设定pass的执行先后顺序
3. 修复图优化后Net的dump 段错误。图优化会删除部分权重，delete Tensor，这部分tensor在Net的inputs中持有，需要同步erase，否则后续访问到会段错误