### PR TITLE
fixed out-of-bounds access in `std::array<float, 4> getOriginBox(const std::array<float, 4> &box,..)`

### DIFF
--- a/plugin/source/nndeploy/detect/util.cc
+++ b/plugin/source/nndeploy/detect/util.cc
@@ -23,9 +23,9 @@ std::array<float, 4> getOriginBox(const std::array<float, 4> &box,
                                   int ori_height) {
   float xmin = std::max(box[0] / scale_factor[0] + x_offset, 0.f);
   float ymin = std::max(box[1] / scale_factor[1] + y_offset, 0.f);
-  float xmax = std::min(box[3] / scale_factor[2] + x_offset,
+  float xmax = std::min(box[2] / scale_factor[2] + x_offset,
                         static_cast<float>(ori_width) - 1.f);
-  float ymax = std::min(box[4] / scale_factor[3] + y_offset,
+  float ymax = std::min(box[3] / scale_factor[3] + y_offset,
                         static_cast<float>(ori_height) - 1.f);
   return {xmin, ymin, xmax, ymax};
 }


### PR DESCRIPTION
fixes #102 