### PR TITLE
Checks for duplicate names in `CreateNode` and `CreateInfer`

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -2,7 +2,8 @@
 [简体中文](README.md) | English
 
 ## Introduction
-nndeploy is an end-to-end deployment framework for models. Centered around `multi-end inference` and `model deployment based on directed acyclic graph`, it is committed to providing users with a cross-platform, simple, easy-to-use, and high-performance model deployment experience.
+nndeploy is an end-to-end model deployment framework. Based on multi-terminal inference and directed acyclic graph model deployment, it is committed to providing users with a cross-platform, easy-to-use, and high-performance model deployment experience.
+
 
 ## Architecture
 ![Architecture](docs/image/architecture.jpg)

--- a/framework/include/nndeploy/dag/graph.h
+++ b/framework/include/nndeploy/dag/graph.h
@@ -419,7 +419,8 @@ template <typename T, typename... Args,
 Node *Graph::createNode(const std::string &name, Edge *input, Edge *output,
                         Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Node *node = dynamic_cast<Node *>(new T(name, input, output, args...));
   NodeWrapper *node_wrapper = new NodeWrapper();
@@ -447,7 +448,8 @@ template <typename T, typename... Args,
 Node *Graph::createNode(const std::string &name, const std::string &input_name,
                         const std::string &output_name, Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Edge *input = getEdge(input_name);
   if (input == nullptr) {
@@ -483,7 +485,8 @@ template <typename T, typename... Args,
 Node *Graph::createNode(const std::string &name, Edge *input,
                         const std::string &output_name, Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Edge *output = getEdge(output_name);
   if (output == nullptr) {
@@ -515,7 +518,8 @@ template <typename T, typename... Args,
 Node *Graph::createNode(const std::string &name, const std::string &input_name,
                         Edge *output, Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Edge *input = getEdge(input_name);
   if (input == nullptr) {
@@ -547,7 +551,8 @@ template <typename T, typename... Args,
 Node *Graph::createNode(const std::string &name, std::vector<Edge *> inputs,
                         std::vector<Edge *> outputs, Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Node *node = dynamic_cast<Node *>(new T(name, inputs, outputs, args...));
   NodeWrapper *node_wrapper = new NodeWrapper();
@@ -580,7 +585,8 @@ Node *Graph::createNode(const std::string &name,
                         std::vector<std::string> input_names,
                         std::vector<std::string> output_names, Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> inputs;
   for (auto input_name : input_names) {
@@ -629,7 +635,8 @@ Node *Graph::createNode(const std::string &name,
                         std::vector<std::string> input_names,
                         std::vector<Edge *> outputs, Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> inputs;
   for (auto input_name : input_names) {
@@ -669,7 +676,8 @@ template <typename T, typename... Args,
 Node *Graph::createNode(const std::string &name, std::vector<Edge *> inputs,
                         std::vector<std::string> output_names, Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> outputs;
   for (auto output_name : output_names) {
@@ -710,7 +718,8 @@ Node *Graph::createNode(const std::string &name,
                         std::initializer_list<Edge *> inputs,
                         std::initializer_list<Edge *> outputs, Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Node *node = dynamic_cast<Node *>(new T(name, inputs, outputs, args...));
   NodeWrapper *node_wrapper = new NodeWrapper();
@@ -744,7 +753,8 @@ Node *Graph::createNode(const std::string &name,
                         std::initializer_list<std::string> output_names,
                         Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> inputs;
   for (auto input_name : input_names) {
@@ -794,7 +804,8 @@ Node *Graph::createNode(const std::string &name,
                         std::initializer_list<std::string> output_names,
                         Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> outputs;
   for (auto output_name : output_names) {
@@ -835,7 +846,8 @@ Node *Graph::createNode(const std::string &name,
                         std::initializer_list<std::string> input_names,
                         std::initializer_list<Edge *> outputs, Args &...args) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> inputs;
   for (auto input_name : input_names) {
@@ -875,7 +887,8 @@ template <typename T, typename... Args,
 Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          Edge *input, Edge *output) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Node *node = dynamic_cast<Node *>(new T(name, type, input, output));
   NodeWrapper *node_wrapper = new NodeWrapper();
@@ -904,7 +917,8 @@ Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          const std::string &input_name,
                          const std::string &output_name) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Edge *input = getEdge(input_name);
   if (input == nullptr) {
@@ -940,7 +954,8 @@ template <typename T, typename... Args,
 Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          Edge *input, const std::string &output_name) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Edge *output = getEdge(output_name);
   if (output == nullptr) {
@@ -972,7 +987,8 @@ template <typename T, typename... Args,
 Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          const std::string &input_name, Edge *output) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Edge *input = getEdge(input_name);
   if (input == nullptr) {
@@ -1005,7 +1021,8 @@ Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          std::vector<Edge *> inputs,
                          std::vector<Edge *> outputs) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Node *node = dynamic_cast<Node *>(new T(name, type, inputs, outputs));
   NodeWrapper *node_wrapper = new NodeWrapper();
@@ -1038,7 +1055,8 @@ Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          std::vector<std::string> input_names,
                          std::vector<std::string> output_names) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> inputs;
   for (auto input_name : input_names) {
@@ -1087,7 +1105,8 @@ Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          std::vector<Edge *> inputs,
                          std::vector<std::string> output_names) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> outputs;
   for (auto output_name : output_names) {
@@ -1128,7 +1147,8 @@ Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          std::vector<std::string> input_names,
                          std::vector<Edge *> outputs) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> inputs;
   for (auto input_name : input_names) {
@@ -1169,7 +1189,8 @@ Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          std::initializer_list<Edge *> inputs,
                          std::initializer_list<Edge *> outputs) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   Node *node = dynamic_cast<Node *>(new T(name, type, inputs, outputs));
   NodeWrapper *node_wrapper = new NodeWrapper();
@@ -1202,7 +1223,8 @@ Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          std::initializer_list<std::string> input_names,
                          std::initializer_list<std::string> output_names) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> inputs;
   for (auto input_name : input_names) {
@@ -1251,7 +1273,8 @@ Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          std::initializer_list<Edge *> inputs,
                          std::initializer_list<std::string> output_names) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> outputs;
   for (auto output_name : output_names) {
@@ -1292,7 +1315,8 @@ Node *Graph::createInfer(const std::string &name, base::InferenceType type,
                          std::initializer_list<std::string> input_names,
                          std::initializer_list<Edge *> outputs) {
   if (used_node_names_.find(name) != used_node_names_.end()) {
-    NNDEPLOY_LOGW("Node name[%s] is already used!\n", name.c_str());
+    NNDEPLOY_LOGE("node name[%s] is already used!\n", name.c_str());
+    return nullptr;
   }
   std::vector<Edge *> inputs;
   for (auto input_name : input_names) {


### PR DESCRIPTION
# What's changed:
- Restored checks for duplicate names in `CreateNode` and `CreateInfer` in framework/include/nndeploy/dag/graph.h
- Updated readme