### PR TITLE
Fix typo: kOpTypeAvaragePool -> kOpTypeAveragePool

### DIFF
--- a/framework/source/nndeploy/ir/op_param.cc
+++ b/framework/source/nndeploy/ir/op_param.cc
@@ -384,7 +384,7 @@ REGISTER_OP_PARAM_IMPLEMENTION(kOpTypeDequantizeLinear, DequantizeLinearParam);
 
 REGISTER_OP_PARAM_IMPLEMENTION(kOpTypeQLinearConv, QLinearConvParam);
 
-REGISTER_OP_PARAM_IMPLEMENTION(kOpTypeAvaragePool, AvaragePoolParam);
+REGISTER_OP_PARAM_IMPLEMENTION(kOpTypeAveragePool, AvaragePoolParam);
 
 }  // namespace ir
 }  // namespace nndeploy


### PR DESCRIPTION
This PR fixes a typo in the constant name `kOpTypeAvaragePool`, correcting it to `kOpTypeAveragePool` to match the correct spelling of "Average".

