### PR TITLE
Fix typo: The word 'create' was inserted into 'global' by mistake.

### DIFF
--- a/demo/detect/demo.cc
+++ b/demo/detect/demo.cc
@@ -82,7 +82,7 @@ int main(int argc, char *argv[]) {
   std::vector<std::string> model_value = demo::getModelValue();
   // input path
   std::string input_path = demo::getInputPath();
-  // input path
+  // codec flag
   base::CodecFlag codec_flag = demo::getCodecFlag();
   // output path
   std::string ouput_path = demo::getOutputPath();
@@ -133,7 +133,7 @@ int main(int argc, char *argv[]) {
         "DrawBoxNode", {&input, &output}, {draw_output});
   }
 
-  // 解码节点
+  // 编码节点
   codec::EncodeNode *encode_node = codec::createEncodeNode(
       base::kCodecTypeOpenCV, codec_flag, "encode_node", draw_output);
   graph->addNode(encode_node);

--- a/docs/zh_cn/knowledge_shared/pybind11.md
+++ b/docs/zh_cn/knowledge_shared/pybind11.md
@@ -139,7 +139,7 @@ std::string toString() override {
 DecodeNode *createDecodeNode(base::CodecType type, base::CodecFlag flag,
                              const std::string &name, dag::Edge *output) {
   DecodeNode *temp = nullptr;
-  auto &map = getGlobaCreatelDecodeNodeFuncMap();
+  auto &map = getGlobalCreateDecodeNodeFuncMap();
   if (map.count(type) > 0) {
     temp = map[type](flag, name, output);
   }
@@ -185,7 +185,7 @@ py::class_<Node, PyNode, std::shared_ptr<Node>>(m, "Node", py::dynamic_attr())
 DecodeNode *createDecodeNode(base::CodecType type, base::CodecFlag flag,
                              const std::string &name, dag::Edge *output) {
   DecodeNode *temp = nullptr;
-  auto &map = getGlobaCreatelDecodeNodeFuncMap();
+  auto &map = getGlobalCreateDecodeNodeFuncMap();
   if (map.count(type) > 0) {
     temp = map[type](flag, name, output);
   }

--- a/plugin/include/nndeploy/codec/codec.h
+++ b/plugin/include/nndeploy/codec/codec.h
@@ -153,16 +153,16 @@ using createDecodeNodeSharedPtrFunc = std::function<std::shared_ptr<DecodeNode>(
     base::CodecFlag flag, const std::string &name, dag::Edge *output)>;
 
 std::map<base::CodecType, createDecodeNodeFunc>
-    &getGlobaCreatelDecodeNodeFuncMap();
+    &getGlobalCreateDecodeNodeFuncMap();
 
 std::map<base::CodecType, createDecodeNodeSharedPtrFunc>
-    &getGlobaCreatelDecodeNodeSharedPtrFuncMap();
+    &getGlobalCreateDecodeNodeSharedPtrFuncMap();
 
 class TypeCreatelDecodeNodeRegister {
  public:
   explicit TypeCreatelDecodeNodeRegister(base::CodecType type,
                                          createDecodeNodeFunc func) {
-    getGlobaCreatelDecodeNodeFuncMap()[type] = func;
+    getGlobalCreateDecodeNodeFuncMap()[type] = func;
   }
 };
 
@@ -170,7 +170,7 @@ class TypeCreatelDecodeNodeSharedPtrRegister {
  public:
   explicit TypeCreatelDecodeNodeSharedPtrRegister(
       base::CodecType type, createDecodeNodeSharedPtrFunc func) {
-    getGlobaCreatelDecodeNodeSharedPtrFuncMap()[type] = func;
+    getGlobalCreateDecodeNodeSharedPtrFuncMap()[type] = func;
   }
 };
 extern NNDEPLOY_CC_API DecodeNode *createDecodeNode(base::CodecType type,
@@ -188,16 +188,16 @@ using createEncodeNodeSharedPtrFunc = std::function<std::shared_ptr<EncodeNode>(
     base::CodecFlag flag, const std::string &name, dag::Edge *input)>;
 
 std::map<base::CodecType, createEncodeNodeFunc>
-    &getGlobaCreatelEncodeNodeFuncMap();
+    &getGlobalCreateEncodeNodeFuncMap();
 
 std::map<base::CodecType, createEncodeNodeSharedPtrFunc>
-    &getGlobaCreatelEncodeNodeSharedPtrFuncMap();
+    &getGlobalCreateEncodeNodeSharedPtrFuncMap();
 
 class TypeCreatelEncodeNodeRegister {
  public:
   explicit TypeCreatelEncodeNodeRegister(base::CodecType type,
                                          createEncodeNodeFunc func) {
-    getGlobaCreatelEncodeNodeFuncMap()[type] = func;
+    getGlobalCreateEncodeNodeFuncMap()[type] = func;
   }
 };
 
@@ -205,7 +205,7 @@ class TypeCreatelEncodeNodeSharedPtrRegister {
  public:
   explicit TypeCreatelEncodeNodeSharedPtrRegister(
       base::CodecType type, createEncodeNodeSharedPtrFunc func) {
-    getGlobaCreatelEncodeNodeSharedPtrFuncMap()[type] = func;
+    getGlobalCreateEncodeNodeSharedPtrFuncMap()[type] = func;
   }
 };
 

--- a/plugin/source/nndeploy/codec/codec.cc
+++ b/plugin/source/nndeploy/codec/codec.cc
@@ -5,7 +5,7 @@ namespace nndeploy {
 namespace codec {
 
 std::map<base::CodecType, createDecodeNodeFunc> &
-getGlobaCreatelDecodeNodeFuncMap() {
+getGlobalCreateDecodeNodeFuncMap() {
   static std::once_flag once;
   static std::shared_ptr<std::map<base::CodecType, createDecodeNodeFunc>>
       creators;
@@ -16,7 +16,7 @@ getGlobaCreatelDecodeNodeFuncMap() {
 }
 
 std::map<base::CodecType, createDecodeNodeSharedPtrFunc> &
-getGlobaCreatelDecodeNodeSharedPtrFuncMap() {
+getGlobalCreateDecodeNodeSharedPtrFuncMap() {
   static std::once_flag once;
   static std::shared_ptr<
       std::map<base::CodecType, createDecodeNodeSharedPtrFunc>>
@@ -31,7 +31,7 @@ getGlobaCreatelDecodeNodeSharedPtrFuncMap() {
 DecodeNode *createDecodeNode(base::CodecType type, base::CodecFlag flag,
                              const std::string &name, dag::Edge *output) {
   DecodeNode *temp = nullptr;
-  auto &map = getGlobaCreatelDecodeNodeFuncMap();
+  auto &map = getGlobalCreateDecodeNodeFuncMap();
   if (map.count(type) > 0) {
     temp = map[type](flag, name, output);
   }
@@ -42,7 +42,7 @@ std::shared_ptr<DecodeNode> createDecodeNodeSharedPtr(base::CodecType type,
                                                       base::CodecFlag flag,
                                                       const std::string &name,
                                                       dag::Edge *output) {
-  auto &map = getGlobaCreatelDecodeNodeSharedPtrFuncMap();
+  auto &map = getGlobalCreateDecodeNodeSharedPtrFuncMap();
   if (map.count(type) > 0) {
     return map[type](flag, name, output);
   }
@@ -50,7 +50,7 @@ std::shared_ptr<DecodeNode> createDecodeNodeSharedPtr(base::CodecType type,
 }
 
 std::map<base::CodecType, createEncodeNodeFunc> &
-getGlobaCreatelEncodeNodeFuncMap() {
+getGlobalCreateEncodeNodeFuncMap() {
   static std::once_flag once;
   static std::shared_ptr<std::map<base::CodecType, createEncodeNodeFunc>>
       creators;
@@ -61,7 +61,7 @@ getGlobaCreatelEncodeNodeFuncMap() {
 }
 
 std::map<base::CodecType, createEncodeNodeSharedPtrFunc> &
-getGlobaCreatelEncodeNodeSharedPtrFuncMap() {
+getGlobalCreateEncodeNodeSharedPtrFuncMap() {
   static std::once_flag once;
   static std::shared_ptr<
       std::map<base::CodecType, createEncodeNodeSharedPtrFunc>>
@@ -76,7 +76,7 @@ getGlobaCreatelEncodeNodeSharedPtrFuncMap() {
 EncodeNode *createEncodeNode(base::CodecType type, base::CodecFlag flag,
                              const std::string &name, dag::Edge *input) {
   EncodeNode *temp = nullptr;
-  auto &map = getGlobaCreatelEncodeNodeFuncMap();
+  auto &map = getGlobalCreateEncodeNodeFuncMap();
   if (map.count(type) > 0) {
     temp = map[type](flag, name, input);
   }
@@ -87,7 +87,7 @@ std::shared_ptr<EncodeNode> createEncodeNodeSharedPtr(base::CodecType type,
                                                       base::CodecFlag flag,
                                                       const std::string &name,
                                                       dag::Edge *input) {
-  auto &map = getGlobaCreatelEncodeNodeSharedPtrFuncMap();
+  auto &map = getGlobalCreateEncodeNodeSharedPtrFuncMap();
   if (map.count(type) > 0) {
     return map[type](flag, name, input);
   }


### PR DESCRIPTION
### Related Issues：#143 


